### PR TITLE
:sparkles: 添加saveBatch方法

### DIFF
--- a/ballcat-extends/ballcat-extend-mybatis-plus/src/main/java/com/hccake/extend/mybatis/plus/service/ExtendService.java
+++ b/ballcat-extends/ballcat-extend-mybatis-plus/src/main/java/com/hccake/extend/mybatis/plus/service/ExtendService.java
@@ -3,11 +3,10 @@ package com.hccake.extend.mybatis.plus.service;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
 import com.baomidou.mybatisplus.core.toolkit.CollectionUtils;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 以前继承 com.baomidou.mybatisplus.extension.service.IService 的实现类，现在继承当前类
@@ -136,5 +135,21 @@ public interface ExtendService<T> {
 	 * @author lingting 2020-08-26 22:11
 	 */
 	boolean saveBatchSomeColumn(Collection<T> list, int batchSize);
+
+	/**
+	 * 插入（批量）
+	 * @param entityList 实体对象集合
+	 */
+	@Transactional(rollbackFor = Exception.class)
+	default boolean saveBatch(Collection<T> entityList) {
+		return saveBatch(entityList, DEFAULT_INSERT_BATCH_SIZE);
+	}
+
+	/**
+	 * 插入（批量）
+	 * @param entityList 实体对象集合
+	 * @param batchSize 插入批次数量
+	 */
+	boolean saveBatch(Collection<T> entityList, int batchSize);
 
 }

--- a/ballcat-extends/ballcat-extend-mybatis-plus/src/main/java/com/hccake/extend/mybatis/plus/service/impl/ExtendServiceImpl.java
+++ b/ballcat-extends/ballcat-extend-mybatis-plus/src/main/java/com/hccake/extend/mybatis/plus/service/impl/ExtendServiceImpl.java
@@ -7,16 +7,15 @@ import com.baomidou.mybatisplus.core.toolkit.ReflectionKit;
 import com.baomidou.mybatisplus.extension.toolkit.SqlHelper;
 import com.hccake.extend.mybatis.plus.mapper.ExtendMapper;
 import com.hccake.extend.mybatis.plus.service.ExtendService;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
 import org.apache.ibatis.binding.MapperMethod;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.function.BiConsumer;
 
 /**
  * 以前继承 com.baomidou.mybatisplus.extension.service.impl.ServiceImpl 的实现类，现在继承本类
@@ -122,6 +121,14 @@ public class ExtendServiceImpl<M extends ExtendMapper<T>, T> implements ExtendSe
 			baseMapper.insertBatchSomeColumn(data);
 		}
 		return true;
+	}
+
+	@Override
+	@Transactional(rollbackFor = Exception.class)
+	public boolean saveBatch(Collection<T> entityList, int batchSize) {
+		String sqlStatement = getSqlStatement(SqlMethod.INSERT_ONE);
+		return SqlHelper.executeBatch(this.entityClass, this.log, entityList, batchSize,
+				((sqlSession, entity) -> sqlSession.insert(sqlStatement, entity)));
 	}
 
 }


### PR DESCRIPTION
经实测, 开启批处理事务以及 rewriteBatchedStatements 后, 一次插入一条数据的速度比一次插入多条的速度更快.

rewriteBatchedStatements在jdbcUrl中设置为true来开启