### PR TITLE
:sparkles: AccessLog 的 body 记录的最大长度控制下放到规则中控制

### DIFF
--- a/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/accesslog/AccessLogAutoConfiguration.java
+++ b/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/accesslog/AccessLogAutoConfiguration.java
@@ -56,7 +56,6 @@ public class AccessLogAutoConfiguration {
 	@ConditionalOnMissingBean(AccessLogFilter.class)
 	public AccessLogFilter defaultAccessLogFilter() {
 		List<AccessLogRule> propertiesRules = this.accessLogProperties.getAccessLogRules();
-		Integer maxBodyLength = this.accessLogProperties.getMaxBodyLength();
 		Integer filterOrder = this.accessLogProperties.getFilterOrder();
 		Level defaultFilterLogLevel = this.accessLogProperties.getDefaultFilterLogLevel();
 		AccessLogRecordOptions defaultRecordOptions = this.accessLogProperties.getDefaultAccessLogRecordOptions();
@@ -69,7 +68,6 @@ public class AccessLogAutoConfiguration {
 		// 创建默认访问日志过滤器
 		AbstractAccessLogFilter accessLogFilter = new DefaultAccessLogFilter(defaultRecordOptions, accessLogRules,
 				defaultFilterLogLevel);
-		accessLogFilter.setMaxBodyLength(maxBodyLength);
 		accessLogFilter.setOrder(filterOrder);
 		return accessLogFilter;
 	}

--- a/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/accesslog/AccessLogProperties.java
+++ b/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/accesslog/AccessLogProperties.java
@@ -63,11 +63,6 @@ public class AccessLogProperties {
 	private Boolean filterAutoRegister = true;
 
 	/**
-	 * 记录的最大的 body 长度
-	 */
-	private Integer maxBodyLength = AbstractAccessLogFilter.DEFAULT_MAX_BODY_LENGTH;
-
-	/**
 	 * 访问日志记录的默认选项，当请求路径无法在 rules 中匹配时，使用该选项
 	 */
 	private RecordOptions defaultRecordOptions = new RecordOptions();
@@ -93,6 +88,8 @@ public class AccessLogProperties {
 			.includeQueryString(recordOptions.isIncludeQueryString())
 			.includeRequestBody(recordOptions.isIncludeRequestBody())
 			.includeResponseBody(recordOptions.isIncludeResponseBody())
+			.maxRequestBodyLength(recordOptions.getMaxRequestBodyLength())
+			.maxResponseBodyLength(recordOptions.getMaxResponseBodyLength())
 			.build();
 	}
 
@@ -123,6 +120,16 @@ public class AccessLogProperties {
 		 * 记录响应体
 		 */
 		private boolean includeResponseBody = false;
+
+		/**
+		 * 记录的最大的请求 body 长度
+		 */
+		private Integer maxRequestBodyLength = AbstractAccessLogFilter.DEFAULT_MAX_BODY_LENGTH;
+
+		/**
+		 * 记录的最大的响应 body 长度
+		 */
+		private Integer maxResponseBodyLength = AbstractAccessLogFilter.DEFAULT_MAX_BODY_LENGTH;
 
 	}
 

--- a/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/accesslog/AccessLogTestConfiguration.java
+++ b/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/accesslog/AccessLogTestConfiguration.java
@@ -57,7 +57,6 @@ public class AccessLogTestConfiguration {
 		AccessLogRecordOptions defaultRecordOptions = this.accessLogProperties.getDefaultAccessLogRecordOptions();
 
 		TestAccessLogFilter accessLogFilter = new TestAccessLogFilter(defaultRecordOptions, accessLogRules);
-		accessLogFilter.setMaxBodyLength(this.accessLogProperties.getMaxBodyLength());
 		accessLogFilter.setOrder(this.accessLogProperties.getFilterOrder());
 		return accessLogFilter;
 	}

--- a/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/accesslog/TestAccessLogFilter.java
+++ b/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/accesslog/TestAccessLogFilter.java
@@ -47,14 +47,14 @@ public class TestAccessLogFilter extends AbstractAccessLogFilter {
 	protected void afterRequest(HttpServletRequest request, HttpServletResponse response, Long executionTime,
 			Throwable throwable, AccessLogRecordOptions recordOptions) {
 		if (recordOptions.isIncludeRequestBody()) {
-			String payload = getRequestBody(request);
+			String payload = getRequestBody(request, recordOptions.getMaxRequestBodyLength());
 			if (payload != null) {
 				this.httpInfo.setRequestBody(payload);
 			}
 		}
 
 		if (recordOptions.isIncludeResponseBody()) {
-			String payload = getResponseBody(response);
+			String payload = getResponseBody(response, recordOptions.getMaxResponseBodyLength());
 			if (payload != null) {
 				this.httpInfo.setResponseBody(payload);
 			}

--- a/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/AccessLogRecordOptions.java
+++ b/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/AccessLogRecordOptions.java
@@ -49,4 +49,14 @@ public class AccessLogRecordOptions {
 	 */
 	private boolean includeResponseBody;
 
+	/**
+	 * 记录的最大的请求 body 长度
+	 */
+	private int maxRequestBodyLength;
+
+	/**
+	 * 记录的最大的响应 body 长度
+	 */
+	private int maxResponseBodyLength;
+
 }

--- a/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/DefaultAccessLogFilter.java
+++ b/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/DefaultAccessLogFilter.java
@@ -104,14 +104,14 @@ public class DefaultAccessLogFilter extends AbstractAccessLogFilter {
 		msg.append(", client=").append(ipAddr);
 
 		if (recordOptions.isIncludeRequestBody()) {
-			String payload = getRequestBody(request);
+			String payload = getRequestBody(request, recordOptions.getMaxRequestBodyLength());
 			if (payload != null) {
 				msg.append(", request body=").append(payload);
 			}
 		}
 
 		if (recordOptions.isIncludeResponseBody()) {
-			String payload = getResponseBody(response);
+			String payload = getResponseBody(response, recordOptions.getMaxResponseBodyLength());
 			if (payload != null) {
 				msg.append(", response body=").append(payload);
 			}

--- a/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/annotation/AccessLogRuleFinder.java
+++ b/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/annotation/AccessLogRuleFinder.java
@@ -81,6 +81,8 @@ public final class AccessLogRuleFinder {
 			.includeQueryString(accessLoggingRule.includeQueryString())
 			.includeRequestBody(accessLoggingRule.includeRequestBody())
 			.includeResponseBody(accessLoggingRule.includeResponseBody())
+			.maxRequestBodyLength(accessLoggingRule.maxRequestBodyLength())
+			.maxResponseBodyLength(accessLoggingRule.maxResponseBodyLength())
 			.build();
 	}
 

--- a/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/annotation/AccessLoggingRule.java
+++ b/web/ballcat-web/src/main/java/org/ballcat/web/accesslog/annotation/AccessLoggingRule.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.ballcat.web.accesslog.AbstractAccessLogFilter;
+
 /**
  * @author Alickx 2023/11/23 17:48
  * @since 2.0.0
@@ -50,5 +52,15 @@ public @interface AccessLoggingRule {
 	 * 记录响应体
 	 */
 	boolean includeResponseBody() default false;
+
+	/**
+	 * 记录的最大的请求 body 长度
+	 */
+	int maxRequestBodyLength() default AbstractAccessLogFilter.DEFAULT_MAX_BODY_LENGTH;
+
+	/**
+	 * 记录的最大的响应 body 长度
+	 */
+	int maxResponseBodyLength() default AbstractAccessLogFilter.DEFAULT_MAX_BODY_LENGTH;
 
 }


### PR DESCRIPTION
AccessLog 的 body 记录的最大长度控制下放到规则中控制，且请求和响应体分开控制。如果值为 -1 表示不控制长度。