### PR TITLE
:recycle: ObjectMapper 注册逻辑优化

### DIFF
--- a/common/ballcat-common-core/src/main/java/org/ballcat/common/core/jackson/NullSerializerProvider.java
+++ b/common/ballcat-common-core/src/main/java/org/ballcat/common/core/jackson/NullSerializerProvider.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
+import lombok.Setter;
 
 /**
  * <p>
@@ -41,9 +42,16 @@ import com.fasterxml.jackson.databind.ser.SerializerFactory;
  *
  * @author hccake
  */
+@Setter
 public class NullSerializerProvider extends DefaultSerializerProvider {
 
 	private static final long serialVersionUID = 1L;
+
+	private boolean writeNullStringValuesAsQuotes = false;
+
+	private boolean writeNullMapValuesAsBraces = false;
+
+	private boolean writeNullArrayValuesAsBrackets = false;
 
 	public NullSerializerProvider() {
 		super();
@@ -77,24 +85,28 @@ public class NullSerializerProvider extends DefaultSerializerProvider {
 		if (getClass() != NullSerializerProvider.class) {
 			return super.copy();
 		}
-		return new NullSerializerProvider(this);
+		NullSerializerProvider nullSerializerProvider = new NullSerializerProvider(this);
+		copyProperties(nullSerializerProvider, this);
+		return nullSerializerProvider;
 	}
 
 	@Override
 	public NullSerializerProvider createInstance(SerializationConfig config, SerializerFactory jsf) {
-		return new NullSerializerProvider(this, config, jsf);
+		NullSerializerProvider nullSerializerProvider = new NullSerializerProvider(this, config, jsf);
+		copyProperties(nullSerializerProvider, this);
+		return nullSerializerProvider;
 	}
 
 	@Override
 	public JsonSerializer<Object> findNullValueSerializer(BeanProperty property) throws JsonMappingException {
 		JavaType propertyType = property.getType();
-		if (isStringType(propertyType)) {
+		if (this.writeNullStringValuesAsQuotes && isStringType(propertyType)) {
 			return this.nullStringJsonSerializer;
 		}
-		else if (isArrayOrCollectionTrype(propertyType)) {
+		else if (this.writeNullArrayValuesAsBrackets && isArrayOrCollectionTrype(propertyType)) {
 			return this.nullArrayJsonSerializer;
 		}
-		else if (isMapType(propertyType)) {
+		else if (this.writeNullMapValuesAsBraces && isMapType(propertyType)) {
 			return this.nullMapJsonSerializer;
 		}
 		else {
@@ -131,6 +143,12 @@ public class NullSerializerProvider extends DefaultSerializerProvider {
 		Class<?> clazz = type.getRawClass();
 		return clazz.isArray() || Collection.class.isAssignableFrom(clazz);
 
+	}
+
+	private void copyProperties(NullSerializerProvider target, NullSerializerProvider src) {
+		target.writeNullStringValuesAsQuotes = src.writeNullStringValuesAsQuotes;
+		target.writeNullMapValuesAsBraces = src.writeNullMapValuesAsBraces;
+		target.writeNullArrayValuesAsBrackets = src.writeNullArrayValuesAsBrackets;
 	}
 
 }

--- a/toolchain/ballcat-codestyle/src/main/resources/ballcat/checkstyle-suppressions.xml
+++ b/toolchain/ballcat-codestyle/src/main/resources/ballcat/checkstyle-suppressions.xml
@@ -7,7 +7,7 @@
 	<suppress files="com.alibaba.excel.*.*\.java" checks="[a-zA-Z0-9]*" />
 
 	<suppress files="org.ballcat.easyexcel.application.ExcelTestApplication" checks="HideUtilityClassConstructorCheck" />
-	<suppress files="org.ballcat.autoconfigure.web.accesslog.TestApplication" checks="HideUtilityClassConstructorCheck" />
+	<suppress files="org.ballcat.autoconfigure.web.TestApplication" checks="HideUtilityClassConstructorCheck" />
 	<suppress files="org.ballcat.pay.wx.domain.DefaultWxDomain" checks="FinalClassCheck" />
 	<suppress files="org.ballcat.autoconfigure.redis.RedisKeyEventAutoConfiguration" checks="HideUtilityClassConstructorCheck" />
 </suppressions>

--- a/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/JacksonProperties.java
+++ b/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/JacksonProperties.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballcat.autoconfigure.web.jackson;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author hccake
+ */
+@Data
+@ConfigurationProperties(prefix = JacksonProperties.PREFIX)
+public class JacksonProperties {
+
+	public static final String PREFIX = "ballcat.jackson";
+
+	/**
+	 * 序列化
+	 */
+	private Serialization serialization;
+
+	/**
+	 * 序列化自定义配置
+	 */
+	@Data
+	public static class Serialization {
+
+		/**
+		 * null string -> ""
+		 */
+		private boolean writeNullStringValuesAsQuotes = false;
+
+		/**
+		 * null map -> {}
+		 */
+		private boolean writeNullMapValuesAsBraces = false;
+
+		/**
+		 * null array -> []
+		 */
+		private boolean writeNullArrayValuesAsBrackets = false;
+
+	}
+
+}

--- a/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/TestApplication.java
+++ b/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/TestApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballcat.autoconfigure.web;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TestApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(TestApplication.class, args);
+	}
+
+}

--- a/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/jackson/Complex.java
+++ b/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/jackson/Complex.java
@@ -14,16 +14,26 @@
  * limitations under the License.
  */
 
-package org.ballcat.autoconfigure.web.accesslog;
+package org.ballcat.autoconfigure.web.jackson;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-@SpringBootApplication
-public class TestApplication {
+import lombok.Data;
 
-	public static void main(String[] args) {
-		SpringApplication.run(TestApplication.class, args);
-	}
+/**
+ * @author evil0th Create on 2024/4/11
+ */
+@Data
+public class Complex {
+
+	private String string;
+
+	private Map<String, Object> map;
+
+	private Set<String> set;
+
+	private List<String> list;
 
 }

--- a/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/jackson/JacksonTest.java
+++ b/web/ballcat-spring-boot-starter-web/src/test/java/org/ballcat/autoconfigure/web/jackson/JacksonTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballcat.autoconfigure.web.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * jackson测试类
+ *
+ * @author evil0th Create on 2024/4/11
+ */
+@SpringBootTest
+public class JacksonTest {
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	void testSerializeEmptyBeans() {
+		assertDoesNotThrow(() -> this.objectMapper.writeValueAsString(new Object()));
+	}
+
+	@Test
+	void testDeSerializeUnescapedControlChars() {
+		assertDoesNotThrow(() -> this.objectMapper.readValue("{\"string\":\"abc\ncba\"}", Complex.class));
+	}
+
+	@Test
+	void testDeSerializeUnknownProperties() {
+		assertDoesNotThrow(() -> this.objectMapper.readValue("{\"unknown\":\"\"}", Complex.class));
+	}
+
+	@Test
+	void testSerializeNull() throws Exception {
+		Complex info = new Complex();
+		String json = this.objectMapper.writeValueAsString(info);
+		assertNotNull(json);
+		assertEquals("{\"string\":\"\",\"map\":{},\"set\":[],\"list\":[]}", json);
+	}
+
+}

--- a/web/ballcat-spring-boot-starter-web/src/test/resources/application.yml
+++ b/web/ballcat-spring-boot-starter-web/src/test/resources/application.yml
@@ -14,4 +14,16 @@ ballcat:
             include-query-string: true
             include-request-body: true
             include-response-body: true
-
+  jackson:
+    serialization:
+      write-null-string-values-as-quotes: true
+      write-null-array-values-as-brackets: true
+      write-null-map-values-as-braces: true
+spring:
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
+    deserialization:
+      fail-on-unknown-properties: false
+    parser:
+      allow-unquoted-control-chars: true


### PR DESCRIPTION
```
        @Bean
	@ConditionalOnClass(ObjectMapper.class)
	@ConditionalOnMissingBean(ObjectMapper.class)
	public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
		// org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration.JacksonObjectMapperConfiguration
		ObjectMapper objectMapper = builder.createXmlMapper(false).build();

		// 对于空对象的序列化不抛异常
		objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
		// 序列化时忽略未知属性
		objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
		// NULL值修改
		objectMapper.setSerializerProvider(new NullSerializerProvider());
		// 有特殊需要转义字符, 不报错
		objectMapper.enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature());
		// 更新 JsonUtils 中的 ObjectMapper，保持容器和工具类中的 ObjectMapper 对象一致
		JacksonJsonToolAdapter.setMapper(objectMapper);

		return objectMapper;
	}
```

其中序列化配置使用 spring boot 原生 jackson 配置即可实现，不应在这里重复处理，会导致配置失效。
可以在项目的配置文件中进行配置。
等效配置如下：
```yml
spring:
  jackson:
    serialization:
      fail-on-empty-beans: false
    deserialization:
      fail-on-unknown-properties: false
    parser:
      allow-unquoted-control-chars: true
```

另外 NullSerializerProvider 中针对不同类型的控制应可以自定义开关。
新配置如下：
```yml
ballcat:
  jackson:
    serialization:
      write-null-string-values-as-quotes: true # null string序列化为""
      write-null-array-values-as-brackets: true # null array序列化为[]
      write-null-map-values-as-braces: true # null map序列化为{}
```