### PR TITLE
:recycle: NullSerializerProvider保留原默认行为，下游代码无需因此添加配置

### DIFF
--- a/common/ballcat-common-core/src/main/java/org/ballcat/common/core/jackson/NullSerializerProvider.java
+++ b/common/ballcat-common-core/src/main/java/org/ballcat/common/core/jackson/NullSerializerProvider.java
@@ -47,11 +47,11 @@ public class NullSerializerProvider extends DefaultSerializerProvider {
 
 	private static final long serialVersionUID = 1L;
 
-	private boolean writeNullStringValuesAsQuotes = false;
+	private boolean writeNullStringValuesAsQuotes = true;
 
-	private boolean writeNullMapValuesAsBraces = false;
+	private boolean writeNullMapValuesAsBraces = true;
 
-	private boolean writeNullArrayValuesAsBrackets = false;
+	private boolean writeNullArrayValuesAsBrackets = true;
 
 	public NullSerializerProvider() {
 		super();

--- a/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/CustomJacksonAutoConfiguration.java
+++ b/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/CustomJacksonAutoConfiguration.java
@@ -49,14 +49,12 @@ public class CustomJacksonAutoConfiguration {
 		return builder -> {
 			if (null != this.jacksonProperties.getSerialization()) {
 				JacksonProperties.Serialization serialization = this.jacksonProperties.getSerialization();
-				final boolean writeNullStringValuesAsQuotes = serialization.isWriteNullStringValuesAsQuotes();
-				final boolean writeNullMapValuesAsBraces = serialization.isWriteNullMapValuesAsBraces();
-				final boolean writeNullArrayValuesAsBrackets = serialization.isWriteNullArrayValuesAsBrackets();
-
 				final NullSerializerProvider nullSerializerProvider = new NullSerializerProvider();
-				nullSerializerProvider.setWriteNullStringValuesAsQuotes(writeNullStringValuesAsQuotes);
-				nullSerializerProvider.setWriteNullMapValuesAsBraces(writeNullMapValuesAsBraces);
-				nullSerializerProvider.setWriteNullArrayValuesAsBrackets(writeNullArrayValuesAsBrackets);
+				nullSerializerProvider
+					.setWriteNullStringValuesAsQuotes(serialization.isWriteNullStringValuesAsQuotes());
+				nullSerializerProvider.setWriteNullMapValuesAsBraces(serialization.isWriteNullMapValuesAsBraces());
+				nullSerializerProvider
+					.setWriteNullArrayValuesAsBrackets(serialization.isWriteNullArrayValuesAsBrackets());
 				builder.postConfigurer(c -> c.setSerializerProvider(nullSerializerProvider));
 			}
 		};

--- a/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/JacksonProperties.java
+++ b/web/ballcat-spring-boot-starter-web/src/main/java/org/ballcat/autoconfigure/web/jackson/JacksonProperties.java
@@ -42,17 +42,17 @@ public class JacksonProperties {
 		/**
 		 * null string -> ""
 		 */
-		private boolean writeNullStringValuesAsQuotes = false;
+		private boolean writeNullStringValuesAsQuotes = true;
 
 		/**
 		 * null map -> {}
 		 */
-		private boolean writeNullMapValuesAsBraces = false;
+		private boolean writeNullMapValuesAsBraces = true;
 
 		/**
 		 * null array -> []
 		 */
-		private boolean writeNullArrayValuesAsBrackets = false;
+		private boolean writeNullArrayValuesAsBrackets = true;
 
 	}
 


### PR DESCRIPTION
- NullSerializerProvider保留原默认行为，下游代码无需因此添加配置
- 修复测试类不通过